### PR TITLE
Update iface.c

### DIFF
--- a/net/mac80211/iface.c
+++ b/net/mac80211/iface.c
@@ -59,11 +59,12 @@ bool __ieee80211_recalc_txpower(struct ieee80211_sub_if_data *sdata)
 
 	power = ieee80211_chandef_max_power(&chanctx_conf->def);
 	rcu_read_unlock();
-
+	
 	if (sdata->deflink.user_power_level != IEEE80211_UNSET_POWER_LEVEL)
 		power = min(power, sdata->deflink.user_power_level);
 
-	if (sdata->deflink.ap_power_level != IEEE80211_UNSET_POWER_LEVEL)
+	if (sdata->ap_power_level != IEEE80211_UNSET_POWER_LEVEL && 
+		sdata->vif.bss_conf.txpower_type != NL80211_TX_POWER_FIXED)
 		power = min(power, sdata->deflink.ap_power_level);
 
 	if (power != sdata->vif.bss_conf.txpower) {


### PR DESCRIPTION
This fixes the Cisco router unstable connection in a lot of cases. Since they broadcast to lower the power until you get disconnected. And it starts again.

For example:
Limiting TX power to 20 (23 - 3) dBm as advertised by 36:3f:1b:57:28:47


Jul 24 12:51:56 aer wpa_supplicant[1085]: wlp88s0: WNM: Disassociation Imminent - Disassociation Timer 10
Jul 24 12:51:56 aer wpa_supplicant[1085]: wlp88s0: WNM: Preferred List Available
Jul 24 12:51:56 aer wpa_supplicant[1085]: wlp88s0: SME: Trying to authenticate with 26:3f:0b:57:1f:da (SSID='TQ Guests' freq=2462 MHz)
Jul 24 12:51:56 aer kernel: wlp88s0: disconnect from AP 26:3f:1b:57:28:47 for new auth to 26:3f:0b:57:1f:da
Jul 24 12:51:56 aer kernel: wlp88s0: authenticate with 26:3f:0b:57:1f:da
Jul 24 12:51:56 aer kernel: wlp88s0: 80 MHz not supported, disabling VHT
Jul 24 12:51:56 aer NetworkManager[1031]: <info>  [1721818316.8159] device (wlp88s0): supplicant interface state: completed -> authenticating
Jul 24 12:51:56 aer NetworkManager[1031]: <info>  [1721818316.8160] device (p2p-dev-wlp88s0): supplicant management interface state: completed -> authenticating
Jul 24 12:51:56 aer NetworkManager[1031]: <info>  [1721818316.8161] device (wlp88s0): ip:dhcp4: restarting
Jul 24 12:51:56 aer kernel: wlp88s0: send auth to 26:3f:0b:57:1f:da (try 1/3)
Jul 24 12:51:56 aer NetworkManager[1031]: <info>  [1721818316.8499] dhcp4 (wlp88s0): canceled DHCP transaction
Jul 24 12:51:56 aer NetworkManager[1031]: <info>  [1721818316.8500] dhcp4 (wlp88s0): activation: beginning transaction (timeout in 45 seconds)
Jul 24 12:51:56 aer NetworkManager[1031]: <info>  [1721818316.8500] dhcp4 (wlp88s0): state changed no lease
Jul 24 12:51:56 aer NetworkManager[1031]: <info>  [1721818316.8501] dhcp4 (wlp88s0): activation: beginning transaction (timeout in 45 seconds)